### PR TITLE
Update LIFF URLs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Follow the below instructions to deploy your app using the Heroku button and Nod
 ### Add the starter app to LIFF
 
 1. Follow the instructions on the page [Adding a LIFF app](https://developers.line.biz/en/docs/liff/registering-liff-apps/). 
-2. Take a note of your LIFF ID, because you'll need it for the next part. The LIFF ID is the final part of the LIFF URL shown in the console: `line://app/{liffId}`.
+2. Take a note of your LIFF ID, because you'll need it for the next part. The LIFF ID is the final part of the LIFF URL shown in the console: `https://liff.line.me/{liffId}`.
 3. Locate the **Scope** option and click the **Edit** button.
 4. Click the **View all** option and enable `chat_message.write`. This scope is required for the LIFF app to send messages on behalf of the user.
 5. Change the status of LIFF app to **Published**.
@@ -129,7 +129,7 @@ Follow the below instructions to deploy your customized app using Heroku and Nod
 ### Add the starter app to LIFF
 
 1. Follow the instructions on the page [Adding a LIFF app](https://developers.line.biz/en/docs/liff/registering-liff-apps/). 
-2. Take a note of your LIFF ID, because you'll need it for the next part. The LIFF ID is the final part of the LIFF URL shown in the console: `line://app/{liffId}`
+2. Take a note of your LIFF ID, because you'll need it for the next part. The LIFF ID is the final part of the LIFF URL shown in the console: `https://liff.line.me/{liffId}`
 
 ### Customize and deploy the app via terminal
 
@@ -208,7 +208,7 @@ Follow the below instructions to deploy your app using the server platform of yo
 ### Add the starter app to LIFF
 
 1. Follow the instructions on the page [Adding a LIFF app](https://developers.line.biz/en/docs/liff/registering-liff-apps/). 
-2. Take a note of your LIFF ID, because you'll need it for the next part. The LIFF ID is the final part of the LIFF URL shown in the console: `line://app/{liffId}`
+2. Take a note of your LIFF ID, because you'll need it for the next part. The LIFF ID is the final part of the LIFF URL shown in the console: `https://liff.line.me/{liffId}`
 
 3. Set your LIFF ID to the `defaultLiffId` variable in `public/liff-starter.js`.
     ```shell


### PR DESCRIPTION
LIFF URLs shown in my console starts with `https://liff.line.me/`, not `line://app/`, and the [document](https://developers.line.biz/en/docs/liff/registering-liff-apps/#registering-liff-app) also says. 