### PR TITLE
Remove in client check for share target picker

### DIFF
--- a/public/liff-starter.js
+++ b/public/liff-starter.js
@@ -185,23 +185,16 @@ function registerButtonHandlers() {
         });
     });
 
-    document.getElementById('shareTargetPicker').addEventListener('click', function() {
-        if (!liff.isInClient()) {
-            sendAlertIfNotInClient();
-        } else {
-            if (liff.isApiAvailable('shareTargetPicker')) {
-                liff.shareTargetPicker([
-                    {
-                        'type': 'text',
-                        'text': 'Hello, World!'
-                    }
-                ])
-                    .then(
-                        document.getElementById('shareTargetPickerMessage').textContent = "Share target picker was launched."
-                    ).catch(function(res) {
-                        document.getElementById('shareTargetPickerMessage').textContent = "Failed to launch share target picker.";
-                    });
-            }
+    document.getElementById('shareTargetPicker').addEventListener('click', function () {
+        if (liff.isApiAvailable('shareTargetPicker')) {
+            liff.shareTargetPicker([{
+                'type': 'text',
+                'text': 'Hello, World!'
+            }]).then(
+                document.getElementById('shareTargetPickerMessage').textContent = "Share target picker was launched."
+            ).catch(function (res) {
+                document.getElementById('shareTargetPickerMessage').textContent = "Failed to launch share target picker.";
+            });
         }
     });
 


### PR DESCRIPTION
According to [the documentation](https://developers.line.biz/en/docs/liff/developing-liff-apps/#developing-a-liff-app), share target picker actually runs on an external browser.