### PR TITLE
Fix environment variables in vanilla

### DIFF
--- a/src/vanilla/index.js
+++ b/src/vanilla/index.js
@@ -3,7 +3,7 @@ import liff from '@line/liff'
 
 document.addEventListener("DOMContentLoaded", function() {
   liff
-    .init({ liffId: process.env.LIFF_ID || '' })
+    .init({ liffId: process.env.LIFF_ID })
     .then(() => {
         console.log("Success! you can do something with LIFF API here.")
     })

--- a/src/vanilla/package.json
+++ b/src/vanilla/package.json
@@ -2,8 +2,8 @@
   "name": "liff-starter-vanilla",
   "version": "0.1.0",
   "scripts": {
-    "dev": "cross-env NODE_ENV=development LIFF_ID=yourliffid webpack-dev-server --progress",
-    "build": "cross-env NODE_ENV=production LIFF_ID=yourliffid webpack"
+    "dev": "cross-env NODE_ENV=development webpack-dev-server --progress",
+    "build": "cross-env NODE_ENV=production webpack"
   },
   "dependencies": {
     "@line/liff": "^2.16.0"

--- a/src/vanilla/webpack.config.js
+++ b/src/vanilla/webpack.config.js
@@ -43,7 +43,9 @@ const commonConfig = {
   },
 
   plugins: [
-    new webpack.EnvironmentPlugin(['LIFF_ID']),
+    new webpack.EnvironmentPlugin({
+      LIFF_ID: 'yourliffid'
+    }),
     new webpack.HotModuleReplacementPlugin(),
     new MiniCssExtractPlugin({
       filename: "[name].css",


### PR DESCRIPTION
# Description

Now, in `src/vanilla`, the environment variable is specified on the script side. Because of this, trying to override the environment variable from the command line will be invalid.  In other words, we cannot set `LIFF_ID`.

To be able to override the environment variable, the default value is now specified in `webpack.config.js` instead of the script.

I have confirmed that `LIFF_ID` is set without any problem on Netlify.

## Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Code style update
- [ ] Refactor

If changing the UI of default theme, please provide the before/after screenshot.

# Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

If yes, please describe the impact.

# You have tested in the following environments: (Providing a detailed version will be better.)

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] Android
- [ ] iOS

# Final checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works