### PR TITLE
Fix an issue where environment variables could not be set correctly

### DIFF
--- a/src/vanilla/.gitignore
+++ b/src/vanilla/.gitignore
@@ -3,3 +3,4 @@
 .DS_Store
 /dist
 .netlify
+.env

--- a/src/vanilla/package.json
+++ b/src/vanilla/package.json
@@ -19,6 +19,7 @@
     "cross-env": "^7.0.3",
     "css-hot-loader": "^1.4.4",
     "css-loader": "^5.0.1",
+    "dotenv-webpack": "^7.0.3",
     "html-webpack-plugin": "^5.3.1",
     "mini-css-extract-plugin": "^1.6.0",
     "style-loader": "^2.0.0",

--- a/src/vanilla/webpack.config.js
+++ b/src/vanilla/webpack.config.js
@@ -3,6 +3,7 @@ const webpack = require('webpack');
 const { merge } = require('webpack-merge');
 const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 const HtmlWebpackPlugin = require('html-webpack-plugin');
+const Dotenv = require('dotenv-webpack');
 
 const env = process.env.NODE_ENV;
 
@@ -43,9 +44,7 @@ const commonConfig = {
   },
 
   plugins: [
-    new webpack.EnvironmentPlugin({
-      LIFF_ID: 'yourliffid'
-    }),
+    new Dotenv({ systemvars: true }),
     new webpack.HotModuleReplacementPlugin(),
     new MiniCssExtractPlugin({
       filename: "[name].css",

--- a/src/vanilla/yarn.lock
+++ b/src/vanilla/yarn.lock
@@ -2377,6 +2377,25 @@ dot-case@^3.0.4:
     no-case "^3.0.4"
     tslib "^2.0.3"
 
+dotenv-defaults@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/dotenv-defaults/-/dotenv-defaults-2.0.2.tgz#6b3ec2e4319aafb70940abda72d3856770ee77ac"
+  integrity sha512-iOIzovWfsUHU91L5i8bJce3NYK5JXeAwH50Jh6+ARUdLiiGlYWfGw6UkzsYqaXZH/hjE/eCd/PlfM/qqyK0AMg==
+  dependencies:
+    dotenv "^8.2.0"
+
+dotenv-webpack@^7.0.3:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/dotenv-webpack/-/dotenv-webpack-7.0.3.tgz#f50ec3c7083a69ec6076e110566720003b7b107b"
+  integrity sha512-O0O9pOEwrk+n1zzR3T2uuXRlw64QxHSPeNN1GaiNBloQFNaCUL9V8jxSVz4jlXXFP/CIqK8YecWf8BAvsSgMjw==
+  dependencies:
+    dotenv-defaults "^2.0.2"
+
+dotenv@^8.2.0:
+  version "8.6.0"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.6.0.tgz#061af664d19f7f4d8fc6e4ff9b584ce237adcb8b"
+  integrity sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==
+
 ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"


### PR DESCRIPTION
# Description

With the #37, environment variables can now be passed from the command line.

However, there was a problem: the environment variables on the server are ignored because the `LIFF_ID` is specified when building with Webpack.

I thought I had checked this in #37, but it seems that the old yarn build was still there. This was the only reason why it seemed to work correctly. Sorry about that.

In this pull request, we use [dotenv](https://github.com/motdotla/dotenv) to set environment variables. We can specify them in the `.env` file, or we can specify the environment variables on the server.

Since dotenv seems to be used internally by both Next.js and Nuxt, I think it is a package that is safe to adopt. Please check it out and let me know what you think.

## Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Code style update
- [ ] Refactor

If changing the UI of default theme, please provide the before/after screenshot.

# Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

If yes, please describe the impact.

# You have tested in the following environments: (Providing a detailed version will be better.)

- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] Android
- [ ] iOS

# Final checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

# Other information
